### PR TITLE
Add AutoroutingPipelineSolver3 to benchmark and bump capacity-autorouter to v0.0.267

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@tsci/seveibar.push-button": "^0.1.1",
     "@tsci/seveibar.reg-5v-to-3v": "^0.0.1",
     "@tsci/seveibar.smd-usb-c": "^0.0.2",
-    "@tscircuit/capacity-autorouter": "^0.0.266",
+    "@tscircuit/capacity-autorouter": "^0.0.267",
     "@tscircuit/checks": "^0.0.87",
     "@tscircuit/core": "^0.0.1005",
     "@tscircuit/footprints": "^0.0.21",

--- a/scripts/run-benchmark/solvers.ts
+++ b/scripts/run-benchmark/solvers.ts
@@ -1,11 +1,13 @@
 import {
   AutoroutingPipeline1_OriginalUnravel,
   AutoroutingPipelineSolver as AutoroutingPipelineSolver2_PortPointPathing,
+  AutoroutingPipelineSolver3_HgPortPointPathing,
 } from "@tscircuit/capacity-autorouter"
 import type { SolverConstructor } from "types/run-benchmark/SolverConstructor"
 
 export const SOLVER_CONSTRUCTOR_LIST: SolverConstructor[] = [
   AutoroutingPipelineSolver2_PortPointPathing,
+  AutoroutingPipelineSolver3_HgPortPointPathing,
   AutoroutingPipeline1_OriginalUnravel,
 ]
 
@@ -16,6 +18,10 @@ export const solverDisplayNameByConstructor = new Map<
   [
     AutoroutingPipelineSolver2_PortPointPathing,
     "AutoroutingPipelineSolver2_PortPointPathing",
+  ],
+  [
+    AutoroutingPipelineSolver3_HgPortPointPathing,
+    "AutoroutingPipelineSolver3_HgPortPointPathing",
   ],
   [
     AutoroutingPipeline1_OriginalUnravel,


### PR DESCRIPTION
### Motivation
- Include the newly merged autorouter `AutoroutingPipelineSolver3_HgPortPointPathing` so `runcbbenchmark` outputs include results for the new solver.
- Update the dependency to `@tscircuit/capacity-autorouter` to `v0.0.267` to obtain the new solver export.

### Description
- Import `AutoroutingPipelineSolver3_HgPortPointPathing` in `scripts/run-benchmark/solvers.ts` and add it to `SOLVER_CONSTRUCTOR_LIST` and `solverDisplayNameByConstructor` so it participates in benchmarks.
- Bump `@tscircuit/capacity-autorouter` in `package.json` to `^0.0.267` to depend on the release that exports the new solver.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69849aee354883288d1e592f3df59cf8)