### PR TITLE
feat: run autorouter benchmarks concurrently

### DIFF
--- a/lib/cli/run/register.ts
+++ b/lib/cli/run/register.ts
@@ -15,6 +15,7 @@ import { solverDisplayNameByConstructor } from "scripts/run-benchmark/solvers"
 
 interface RunOptions {
   scenarioLimit?: string
+  concurrency?: string
   output?: string
 }
 
@@ -61,6 +62,10 @@ export const registerRun = (program: Command) => {
     .argument("<autorouter-path>", "Path to autorouter TypeScript file")
     .argument("[solver-name]", "Specific export name to use as solver")
     .option("-l, --scenario-limit <count>", "Limit number of scenarios to run")
+    .option(
+      "-c, --concurrency <count>",
+      "Number of benchmark jobs to run in parallel",
+    )
     .option("-o, --output <path>", "Output HTML file path")
     .action(
       async (
@@ -97,6 +102,9 @@ export const registerRun = (program: Command) => {
           const scenarioCountLimit = options.scenarioLimit
             ? Number.parseInt(options.scenarioLimit, 10)
             : null
+          const concurrency = options.concurrency
+            ? Number.parseInt(options.concurrency, 10)
+            : undefined
 
           const scenarioList = await loadScenarioList({
             datasetDirectory,
@@ -119,6 +127,7 @@ export const registerRun = (program: Command) => {
           const { resultRowList, scenarioResultList } = await runBenchmark({
             scenarioList,
             solverConstructorList: [solverConstructor],
+            concurrency,
           })
 
           const outputText = outputTabled({ resultRowList, scenarioList })

--- a/scripts/run-benchmark/getCliOptionsFromArgList.ts
+++ b/scripts/run-benchmark/getCliOptionsFromArgList.ts
@@ -1,7 +1,16 @@
 type CliOptions = {
   scenarioCountLimit: number | null
+  concurrency: number | null
   outputDirectory: string
   shouldShowHelp: boolean
+}
+
+const parsePositiveInteger = (input: string): number | null => {
+  const numericInput = Number(input)
+  if (!Number.isFinite(numericInput)) return null
+
+  const integerValue = Math.floor(numericInput)
+  return integerValue > 0 ? integerValue : null
 }
 
 /**
@@ -11,20 +20,27 @@ const getCliOptionsFromArgList = (argList: string[]): CliOptions => {
   const defaultOutputDirectory = process.cwd()
   const cliOptions: CliOptions = {
     scenarioCountLimit: null,
+    concurrency: null,
     outputDirectory: defaultOutputDirectory,
     shouldShowHelp: false,
   }
-  let parseState: "default" | "scenario_limit" | "output_dir" = "default"
+  let parseState: "default" | "scenario_limit" | "concurrency" | "output_dir" =
+    "default"
 
   for (const arg of argList) {
     switch (parseState) {
       case "scenario_limit": {
-        const scenarioCountLimitInput = Number(arg)
-        if (Number.isFinite(scenarioCountLimitInput)) {
-          const scenarioCountLimitValue = Math.floor(scenarioCountLimitInput)
-          if (scenarioCountLimitValue > 0) {
-            cliOptions.scenarioCountLimit = scenarioCountLimitValue
-          }
+        const scenarioCountLimit = parsePositiveInteger(arg)
+        if (scenarioCountLimit !== null) {
+          cliOptions.scenarioCountLimit = scenarioCountLimit
+        }
+        parseState = "default"
+        break
+      }
+      case "concurrency": {
+        const concurrency = parsePositiveInteger(arg)
+        if (concurrency !== null) {
+          cliOptions.concurrency = concurrency
         }
         parseState = "default"
         break
@@ -41,16 +57,21 @@ const getCliOptionsFromArgList = (argList: string[]): CliOptions => {
           cliOptions.shouldShowHelp = true
         } else if (arg === "--scenario-limit") {
           parseState = "scenario_limit"
+        } else if (arg === "--concurrency") {
+          parseState = "concurrency"
         } else if (arg === "--output-dir") {
           parseState = "output_dir"
         } else if (arg.startsWith("--scenario-limit=")) {
           const scenarioLimitText = arg.split("=", 2)[1]
-          const scenarioLimitNumber = Number(scenarioLimitText)
-          if (Number.isFinite(scenarioLimitNumber)) {
-            const scenarioCountLimitValue = Math.floor(scenarioLimitNumber)
-            if (scenarioCountLimitValue > 0) {
-              cliOptions.scenarioCountLimit = scenarioCountLimitValue
-            }
+          const scenarioCountLimit = parsePositiveInteger(scenarioLimitText)
+          if (scenarioCountLimit !== null) {
+            cliOptions.scenarioCountLimit = scenarioCountLimit
+          }
+        } else if (arg.startsWith("--concurrency=")) {
+          const concurrencyText = arg.split("=", 2)[1]
+          const concurrency = parsePositiveInteger(concurrencyText)
+          if (concurrency !== null) {
+            cliOptions.concurrency = concurrency
           }
         } else if (arg.startsWith("--output-dir=")) {
           const outputDirectoryText = arg.split("=", 2)[1]

--- a/scripts/run-benchmark/index.ts
+++ b/scripts/run-benchmark/index.ts
@@ -25,6 +25,7 @@ const main = async () => {
         "",
         "Options:",
         "  --scenario-limit <count>  Limit number of scenarios (default: all)",
+        "  --concurrency <count>     Number of benchmark jobs to run in parallel (default: CPU count)",
         "  --output-dir <path>       Output directory (default: cwd)",
         "  -h, --help                Show this help text",
         "",
@@ -53,6 +54,7 @@ const main = async () => {
   const { resultRowList, scenarioResultList } = await runBenchmark({
     scenarioList,
     solverConstructorList: SOLVER_CONSTRUCTOR_LIST,
+    concurrency: cliOptions.concurrency ?? undefined,
   })
 
   const outputText = outputTabled({ resultRowList, scenarioList })

--- a/scripts/run-benchmark/runBenchmark.ts
+++ b/scripts/run-benchmark/runBenchmark.ts
@@ -1,3 +1,4 @@
+import { availableParallelism, cpus } from "node:os"
 import { getSvgFromGraphicsObject } from "graphics-debug"
 import { detectUnfixableRoutingIssues } from "lib/checks/detectUnfixableRoutingIssues"
 import { convertToCircuitJson } from "lib/converter/srj-to-circuit-json"
@@ -10,12 +11,51 @@ import type { BenchmarkScenarioResult } from "types/run-benchmark/BenchmarkScena
 import type { Scenario } from "types/run-benchmark/Scenario"
 import type { SolverConstructor } from "types/run-benchmark/SolverConstructor"
 
+type ScenarioRunResult = {
+  elapsedMs: number
+  solved: boolean
+  relaxedDrcPassed: boolean
+}
+
+const getDefaultConcurrency = (totalRunCount: number): number => {
+  const detectedParallelism =
+    typeof availableParallelism === "function"
+      ? availableParallelism()
+      : cpus().length
+
+  return Math.max(1, Math.min(detectedParallelism || 1, totalRunCount || 1))
+}
+
+const runWithConcurrency = async <TInput, TOutput>(inputs: {
+  itemList: TInput[]
+  concurrency: number
+  worker: (item: TInput) => Promise<TOutput>
+}): Promise<TOutput[]> => {
+  const { itemList, concurrency, worker } = inputs
+  const resultList: TOutput[] = new Array(itemList.length)
+  let nextIndex = 0
+
+  const workerCount = Math.min(concurrency, itemList.length)
+  await Promise.all(
+    Array.from({ length: workerCount }, async () => {
+      while (nextIndex < itemList.length) {
+        const itemIndex = nextIndex
+        nextIndex += 1
+        resultList[itemIndex] = await worker(itemList[itemIndex])
+      }
+    }),
+  )
+
+  return resultList
+}
+
 /**
  * Run the benchmark across scenarios and solvers.
  */
 const runBenchmark = async (inputs: {
   scenarioList: Scenario[]
   solverConstructorList: SolverConstructor[]
+  concurrency?: number
 }): Promise<BenchmarkResult> => {
   const { scenarioList, solverConstructorList } = inputs
   const resultRowList: BenchmarkRow[] = []
@@ -30,67 +70,93 @@ const runBenchmark = async (inputs: {
   const totalRunCount = scenarioList.length * solverConstructorList.length
   let completedRunCount = 0
   let averageRunTimeMs = 0
+  const requestedConcurrency =
+    inputs.concurrency !== undefined && Number.isFinite(inputs.concurrency)
+      ? Math.floor(inputs.concurrency)
+      : getDefaultConcurrency(totalRunCount)
+  const concurrency = Math.max(
+    1,
+    Math.min(requestedConcurrency, totalRunCount || 1),
+  )
+
+  console.log(`Running up to ${concurrency} benchmark jobs in parallel.`)
 
   for (const solverClass of solverConstructorList) {
     const solverDisplayName =
       solverDisplayNameByConstructor.get(solverClass) ?? solverClass.name
-    let totalTimeMs = 0
-    let successCount = 0
-    let relaxedDrcPassedCount = 0
-    const elapsedTimeMsList: number[] = []
 
-    for (const [scenarioIndex, scenario] of scenarioList.entries()) {
-      const solver = new solverClass(scenario.simpleRouteJson)
-      // Generate circuit preview SVG before running the solver
-      const rawSvg = getSvgFromGraphicsObject(solver.visualize())
-      scenarioResultList[scenarioIndex].circuitPreviewSvg = rawSvg
-      const startMs = Date.now()
-      try {
-        solver.solve()
-      } catch (_error) {
-        solver.solved = false
-      }
-      const elapsedMs = Date.now() - startMs
-      const connectionsCount = scenario.simpleRouteJson.connections?.length ?? 0
-      totalTimeMs += elapsedMs
-      const solved = solver.solved
-      if (solved) {
-        successCount += 1
-        elapsedTimeMsList.push(elapsedMs)
-      }
-      const scenarioStatus = solved ? "Solved" : "Failed"
-      console.log(
-        `[${solverDisplayName}] ${scenarioStatus} ${scenario.scenarioName} in ${formatTimeSeconds(elapsedMs)} (connections: ${connectionsCount})`,
-      )
-      completedRunCount += 1
-      averageRunTimeMs +=
-        (elapsedMs - averageRunTimeMs) / Math.max(completedRunCount, 1)
-      const remainingRunCount = Math.max(totalRunCount - completedRunCount, 0)
-      const etaMs = Math.max(averageRunTimeMs * remainingRunCount, 0)
-      const percentComplete =
-        totalRunCount === 0 ? 100 : (completedRunCount / totalRunCount) * 100
-      console.log(
-        `[Progress] ${completedRunCount}/${totalRunCount} (${percentComplete.toFixed(1)}%) ETA ${formatTimeSeconds(etaMs)}`,
-      )
+    const scenarioRunResultList = await runWithConcurrency({
+      itemList: scenarioList.map((scenario, scenarioIndex) => ({
+        scenario,
+        scenarioIndex,
+      })),
+      concurrency,
+      worker: async ({
+        scenario,
+        scenarioIndex,
+      }): Promise<ScenarioRunResult> => {
+        const solver = new solverClass(scenario.simpleRouteJson)
+        // Generate circuit preview SVG before running the solver
+        const rawSvg = getSvgFromGraphicsObject(solver.visualize())
+        scenarioResultList[scenarioIndex].circuitPreviewSvg = rawSvg
+        const startMs = Date.now()
+        try {
+          solver.solve()
+        } catch (_error) {
+          solver.solved = false
+        }
+        const elapsedMs = Date.now() - startMs
+        const connectionsCount =
+          scenario.simpleRouteJson.connections?.length ?? 0
+        const solved = solver.solved
+        const scenarioStatus = solved ? "Solved" : "Failed"
+        console.log(
+          `[${solverDisplayName}] ${scenarioStatus} ${scenario.scenarioName} in ${formatTimeSeconds(elapsedMs)} (connections: ${connectionsCount})`,
+        )
 
-      const circuitJson = convertToCircuitJson({
-        srjWithPointPairs: solver.srjWithPointPairs! as any,
-        minTraceWidth: scenario.simpleRouteJson.minTraceWidth,
-        minViaDiameter: scenario.simpleRouteJson.minViaDiameter,
-        routes: !solver.failed ? solver.getOutputSimplifiedPcbTraces() : [],
-      })
-      const relaxedDrcPassed = await detectUnfixableRoutingIssues(circuitJson)
-      if (relaxedDrcPassed && solver.solved) {
-        relaxedDrcPassedCount += 1
-      }
-      scenarioResultList[scenarioIndex].solverResultBySolverName[
-        solverDisplayName
-      ] = {
-        didSolve: solved,
-        elapsedTimeMs: elapsedMs,
-        relaxedDrcPassed,
-      }
-    }
+        const circuitJson = convertToCircuitJson({
+          srjWithPointPairs: solver.srjWithPointPairs! as any,
+          minTraceWidth: scenario.simpleRouteJson.minTraceWidth,
+          minViaDiameter: scenario.simpleRouteJson.minViaDiameter,
+          routes: !solver.failed ? solver.getOutputSimplifiedPcbTraces() : [],
+        })
+        const relaxedDrcPassed = await detectUnfixableRoutingIssues(circuitJson)
+        scenarioResultList[scenarioIndex].solverResultBySolverName[
+          solverDisplayName
+        ] = {
+          didSolve: solved,
+          elapsedTimeMs: elapsedMs,
+          relaxedDrcPassed,
+        }
+
+        completedRunCount += 1
+        averageRunTimeMs +=
+          (elapsedMs - averageRunTimeMs) / Math.max(completedRunCount, 1)
+        const remainingRunCount = Math.max(totalRunCount - completedRunCount, 0)
+        const etaMs = Math.max(averageRunTimeMs * remainingRunCount, 0)
+        const percentComplete =
+          totalRunCount === 0 ? 100 : (completedRunCount / totalRunCount) * 100
+        console.log(
+          `[Progress] ${completedRunCount}/${totalRunCount} (${percentComplete.toFixed(1)}%) ETA ${formatTimeSeconds(etaMs)}`,
+        )
+
+        return { elapsedMs, solved, relaxedDrcPassed }
+      },
+    })
+
+    const totalTimeMs = scenarioRunResultList.reduce(
+      (sum, result) => sum + result.elapsedMs,
+      0,
+    )
+    const successCount = scenarioRunResultList.filter(
+      (result) => result.solved,
+    ).length
+    const relaxedDrcPassedCount = scenarioRunResultList.filter(
+      (result) => result.solved && result.relaxedDrcPassed,
+    ).length
+    const elapsedTimeMsList = scenarioRunResultList
+      .filter((result) => result.solved)
+      .map((result) => result.elapsedMs)
 
     const scenarioCount = scenarioList.length
     const successRatePercent =

--- a/tests/run-benchmark/get-cli-options-from-arg-list.test.ts
+++ b/tests/run-benchmark/get-cli-options-from-arg-list.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from "bun:test"
+import { getCliOptionsFromArgList } from "scripts/run-benchmark/getCliOptionsFromArgList"
+
+describe("getCliOptionsFromArgList", () => {
+  test("parses concurrency from separate arg", () => {
+    expect(getCliOptionsFromArgList(["--concurrency", "4"]).concurrency).toBe(4)
+  })
+
+  test("parses concurrency from equals arg", () => {
+    expect(getCliOptionsFromArgList(["--concurrency=3"]).concurrency).toBe(3)
+  })
+
+  test("ignores invalid concurrency values", () => {
+    expect(getCliOptionsFromArgList(["--concurrency", "0"]).concurrency).toBe(
+      null,
+    )
+  })
+})


### PR DESCRIPTION
Fixes #67

Summary:
- Add bounded concurrency to `runBenchmark`, defaulting to the detected CPU parallelism.
- Add `--concurrency` support to the benchmark script and packaged `autorouting-dataset-runner run` command.
- Keep result aggregation in solver order while reporting progress as jobs complete.
- Add parser coverage for the new concurrency CLI option.

Verification:
- `bun test tests\run-benchmark\get-cli-options-from-arg-list.test.ts`
- `bun x biome check scripts\run-benchmark\getCliOptionsFromArgList.ts scripts\run-benchmark\runBenchmark.ts scripts\run-benchmark\index.ts lib\cli\run\register.ts tests\run-benchmark\get-cli-options-from-arg-list.test.ts`
- `bun run build:cli`
- `bun scripts\run-benchmark\index.ts --scenario-limit 1 --concurrency 2 --output-dir .tmp-benchmark-check`
- `git diff --check`

Note: `bun x tsc --noEmit` still reports existing main-branch type issues in `scripts/run-benchmark/solvers.ts` and `vite.config.ts`; this change does not add new typecheck errors in the edited files.