### PR TITLE
feat: show previous best benchmark result

### DIFF
--- a/lib/cli/run/register.ts
+++ b/lib/cli/run/register.ts
@@ -8,6 +8,7 @@ import { loadUserAutorouter } from "lib/cli/loadUserAutorouter"
 import { buildBenchmarkDetailsJson } from "scripts/run-benchmark/buildBenchmarkDetailsJson"
 import { buildBenchmarkSummaryJson } from "scripts/run-benchmark/buildBenchmarkSummaryJson"
 import { generateHtmlVisualization } from "scripts/run-benchmark/generateHtmlVisualization"
+import { loadPreviousBestBenchmarkRow } from "scripts/run-benchmark/loadPreviousBestBenchmarkRow"
 import { loadScenarioList } from "scripts/run-benchmark/loadScenarioList"
 import { outputTabled } from "scripts/run-benchmark/outputTabled"
 import { runBenchmark } from "scripts/run-benchmark/runBenchmark"
@@ -16,6 +17,7 @@ import { solverDisplayNameByConstructor } from "scripts/run-benchmark/solvers"
 interface RunOptions {
   scenarioLimit?: string
   output?: string
+  previousResults?: string
 }
 
 const findDatasetDirectory = async (): Promise<string> => {
@@ -62,6 +64,10 @@ export const registerRun = (program: Command) => {
     .argument("[solver-name]", "Specific export name to use as solver")
     .option("-l, --scenario-limit <count>", "Limit number of scenarios to run")
     .option("-o, --output <path>", "Output HTML file path")
+    .option(
+      "--previous-results <path>",
+      "Previous benchmark-output.json to show old best result",
+    )
     .action(
       async (
         autorouterPath: string,
@@ -121,13 +127,22 @@ export const registerRun = (program: Command) => {
             solverConstructorList: [solverConstructor],
           })
 
-          const outputText = outputTabled({ resultRowList, scenarioList })
+          const previousBestRow = await loadPreviousBestBenchmarkRow(
+            options.previousResults,
+          )
+
+          const outputText = outputTabled({
+            resultRowList,
+            scenarioList,
+            previousBestRow,
+          })
           console.log("")
           console.log(outputText)
 
           const summaryJson = buildBenchmarkSummaryJson({
             resultRowList,
             scenarioList,
+            previousBestRow,
           })
           const detailJson = buildBenchmarkDetailsJson({
             scenarioResultList,

--- a/scripts/run-benchmark/buildBenchmarkSummaryJson.ts
+++ b/scripts/run-benchmark/buildBenchmarkSummaryJson.ts
@@ -8,20 +8,26 @@ import type { Scenario } from "types/run-benchmark/Scenario"
 const buildBenchmarkSummaryJson = (inputs: {
   resultRowList: BenchmarkRow[]
   scenarioList: Scenario[]
+  previousBestRow?: BenchmarkRow | null
 }): {
   tableHeaderList: string[]
   tableRowList: string[][]
   scenarioCount: number
+  resultRowList: BenchmarkRow[]
+  previousBestRow: BenchmarkRow | null
 } => {
-  const { resultRowList, scenarioList } = inputs
+  const { resultRowList, scenarioList, previousBestRow = null } = inputs
   const { tableHeaderList, tableRowList } = buildBenchmarkTableRows({
     resultRowList,
+    previousBestRow,
   })
 
   return {
     tableHeaderList,
     tableRowList,
     scenarioCount: scenarioList.length,
+    resultRowList,
+    previousBestRow,
   }
 }
 

--- a/scripts/run-benchmark/buildBenchmarkTableRows.ts
+++ b/scripts/run-benchmark/buildBenchmarkTableRows.ts
@@ -6,8 +6,9 @@ import type { BenchmarkRow } from "types/run-benchmark/BenchmarkRow"
  */
 const buildBenchmarkTableRows = (inputs: {
   resultRowList: BenchmarkRow[]
+  previousBestRow?: BenchmarkRow | null
 }): { tableHeaderList: string[]; tableRowList: string[][] } => {
-  const { resultRowList } = inputs
+  const { resultRowList, previousBestRow } = inputs
   const tableHeaderList = [
     "Solver",
     "Completed %",
@@ -25,6 +26,18 @@ const buildBenchmarkTableRows = (inputs: {
     formatTimeSeconds(result.p50TimeMs),
     formatTimeSeconds(result.p95TimeMs),
   ])
+
+  if (previousBestRow) {
+    tableRowList.push([
+      `Old Best (${previousBestRow.solverName})`,
+      `${previousBestRow.successRatePercent.toFixed(1)}%`,
+      previousBestRow.relaxedDrcRatePercent === null
+        ? "n/a"
+        : `${previousBestRow.relaxedDrcRatePercent.toFixed(1)}%`,
+      formatTimeSeconds(previousBestRow.p50TimeMs),
+      formatTimeSeconds(previousBestRow.p95TimeMs),
+    ])
+  }
 
   return { tableHeaderList, tableRowList }
 }

--- a/scripts/run-benchmark/generateHtmlVisualization/generateHeader.ts
+++ b/scripts/run-benchmark/generateHtmlVisualization/generateHeader.ts
@@ -1,9 +1,20 @@
+import { formatTimeSeconds } from "scripts/run-benchmark/formatTimeSeconds"
+import type { BenchmarkRow } from "types/run-benchmark/BenchmarkRow"
+
 /**
  * Generates the HTML header section with benchmark title and scenario count.
  */
-export const generateHeader = (summary_json: { scenarioCount: number }) => {
+export const generateHeader = (summary_json: {
+  scenarioCount: number
+  previousBestRow?: BenchmarkRow | null
+}) => {
+  const previousBestHtml = summary_json.previousBestRow
+    ? `<p class="text-gray-600">Old Best: <span class="font-semibold text-gray-800">${summary_json.previousBestRow.solverName}</span> - ${summary_json.previousBestRow.successRatePercent.toFixed(1)}% solved - P50 ${formatTimeSeconds(summary_json.previousBestRow.p50TimeMs)}</p>`
+    : ""
+
   return `<header class="mb-8">
     <h1 class="text-4xl font-bold text-blue-600 mb-2">Autorouting Benchmark Results</h1>
     <p class="text-gray-600">Total Scenarios: ${summary_json.scenarioCount}</p>
+    ${previousBestHtml}
 </header>`
 }

--- a/scripts/run-benchmark/generateHtmlVisualization/index.ts
+++ b/scripts/run-benchmark/generateHtmlVisualization/index.ts
@@ -17,6 +17,7 @@ export const generateHtmlVisualization = (inputs: {
     tableHeaderList: string[]
     tableRowList: string[][]
     scenarioCount: number
+    previousBestRow?: BenchmarkRow | null
   }
   detail_json: BenchmarkDetailsJson
   result_row_list: BenchmarkRow[]

--- a/scripts/run-benchmark/getCliOptionsFromArgList.ts
+++ b/scripts/run-benchmark/getCliOptionsFromArgList.ts
@@ -1,6 +1,7 @@
 type CliOptions = {
   scenarioCountLimit: number | null
   outputDirectory: string
+  previousResultsPath: string | null
   shouldShowHelp: boolean
 }
 
@@ -12,9 +13,14 @@ const getCliOptionsFromArgList = (argList: string[]): CliOptions => {
   const cliOptions: CliOptions = {
     scenarioCountLimit: null,
     outputDirectory: defaultOutputDirectory,
+    previousResultsPath: null,
     shouldShowHelp: false,
   }
-  let parseState: "default" | "scenario_limit" | "output_dir" = "default"
+  let parseState:
+    | "default"
+    | "scenario_limit"
+    | "output_dir"
+    | "previous_results" = "default"
 
   for (const arg of argList) {
     switch (parseState) {
@@ -36,6 +42,13 @@ const getCliOptionsFromArgList = (argList: string[]): CliOptions => {
         parseState = "default"
         break
       }
+      case "previous_results": {
+        if (arg.length > 0) {
+          cliOptions.previousResultsPath = arg
+        }
+        parseState = "default"
+        break
+      }
       default: {
         if (arg === "--help" || arg === "-h") {
           cliOptions.shouldShowHelp = true
@@ -43,6 +56,8 @@ const getCliOptionsFromArgList = (argList: string[]): CliOptions => {
           parseState = "scenario_limit"
         } else if (arg === "--output-dir") {
           parseState = "output_dir"
+        } else if (arg === "--previous-results") {
+          parseState = "previous_results"
         } else if (arg.startsWith("--scenario-limit=")) {
           const scenarioLimitText = arg.split("=", 2)[1]
           const scenarioLimitNumber = Number(scenarioLimitText)
@@ -56,6 +71,11 @@ const getCliOptionsFromArgList = (argList: string[]): CliOptions => {
           const outputDirectoryText = arg.split("=", 2)[1]
           if (outputDirectoryText.length > 0) {
             cliOptions.outputDirectory = outputDirectoryText
+          }
+        } else if (arg.startsWith("--previous-results=")) {
+          const previousResultsText = arg.split("=", 2)[1]
+          if (previousResultsText.length > 0) {
+            cliOptions.previousResultsPath = previousResultsText
           }
         }
         break

--- a/scripts/run-benchmark/index.ts
+++ b/scripts/run-benchmark/index.ts
@@ -3,6 +3,7 @@ import { buildBenchmarkDetailsJson } from "scripts/run-benchmark/buildBenchmarkD
 import { buildBenchmarkSummaryJson } from "scripts/run-benchmark/buildBenchmarkSummaryJson"
 import { generateHtmlVisualization } from "scripts/run-benchmark/generateHtmlVisualization"
 import { getCliOptionsFromArgList } from "scripts/run-benchmark/getCliOptionsFromArgList"
+import { loadPreviousBestBenchmarkRow } from "scripts/run-benchmark/loadPreviousBestBenchmarkRow"
 import { loadScenarioList } from "scripts/run-benchmark/loadScenarioList"
 import { outputTabled } from "scripts/run-benchmark/outputTabled"
 import { runBenchmark } from "scripts/run-benchmark/runBenchmark"
@@ -26,6 +27,7 @@ const main = async () => {
         "Options:",
         "  --scenario-limit <count>  Limit number of scenarios (default: all)",
         "  --output-dir <path>       Output directory (default: cwd)",
+        "  --previous-results <path> Previous benchmark-output.json to show old best result",
         "  -h, --help                Show this help text",
         "",
         "Examples:",
@@ -55,10 +57,22 @@ const main = async () => {
     solverConstructorList: SOLVER_CONSTRUCTOR_LIST,
   })
 
-  const outputText = outputTabled({ resultRowList, scenarioList })
+  const previousBestRow = await loadPreviousBestBenchmarkRow(
+    cliOptions.previousResultsPath,
+  )
+
+  const outputText = outputTabled({
+    resultRowList,
+    scenarioList,
+    previousBestRow,
+  })
   console.log(outputText)
 
-  const summaryJson = buildBenchmarkSummaryJson({ resultRowList, scenarioList })
+  const summaryJson = buildBenchmarkSummaryJson({
+    resultRowList,
+    scenarioList,
+    previousBestRow,
+  })
   const detailJson = buildBenchmarkDetailsJson({
     scenarioResultList,
     scenarioList,

--- a/scripts/run-benchmark/loadPreviousBestBenchmarkRow.ts
+++ b/scripts/run-benchmark/loadPreviousBestBenchmarkRow.ts
@@ -1,0 +1,159 @@
+import { readFile } from "node:fs/promises"
+import type { BenchmarkRow } from "types/run-benchmark/BenchmarkRow"
+
+type BenchmarkSummaryLike = {
+  resultRowList?: unknown
+  tableHeaderList?: unknown
+  tableRowList?: unknown
+}
+
+const isFiniteNumber = (value: unknown): value is number =>
+  typeof value === "number" && Number.isFinite(value)
+
+const isBenchmarkRow = (value: unknown): value is BenchmarkRow => {
+  if (!value || typeof value !== "object") return false
+
+  const row = value as Partial<BenchmarkRow>
+  return (
+    typeof row.solverName === "string" &&
+    isFiniteNumber(row.totalTimeMs) &&
+    (row.p50TimeMs === null || isFiniteNumber(row.p50TimeMs)) &&
+    (row.p95TimeMs === null || isFiniteNumber(row.p95TimeMs)) &&
+    isFiniteNumber(row.successRatePercent) &&
+    (row.relaxedDrcRatePercent === null ||
+      isFiniteNumber(row.relaxedDrcRatePercent))
+  )
+}
+
+const parsePercentCell = (cellText: string): number | null => {
+  const normalized = cellText.trim().replace(/%$/, "")
+  const percent = Number(normalized)
+  return Number.isFinite(percent) ? percent : null
+}
+
+const parseTimeCell = (cellText: string): number | null => {
+  const normalized = cellText.trim().toLowerCase()
+  if (normalized === "n/a") return null
+
+  const match = normalized.match(/^([0-9.]+)\s*(ms|s)$/)
+  if (!match) return null
+
+  const value = Number(match[1])
+  if (!Number.isFinite(value)) return null
+
+  return match[2] === "ms" ? value : value * 1000
+}
+
+const getColumnIndex = (headers: string[], label: string): number =>
+  headers.findIndex((header) => header.trim().toLowerCase() === label)
+
+const getBenchmarkRowsFromSummaryTable = (
+  summary: BenchmarkSummaryLike,
+): BenchmarkRow[] => {
+  if (
+    !Array.isArray(summary.tableHeaderList) ||
+    !Array.isArray(summary.tableRowList) ||
+    !summary.tableHeaderList.every((header) => typeof header === "string")
+  ) {
+    return []
+  }
+
+  const headers = summary.tableHeaderList as string[]
+  const solverIndex = getColumnIndex(headers, "solver")
+  const completedIndex = getColumnIndex(headers, "completed %")
+  const relaxedDrcIndex = getColumnIndex(headers, "relaxed drc pass %")
+  const p50Index = getColumnIndex(headers, "p50 time")
+  const p95Index = getColumnIndex(headers, "p95 time")
+
+  if (
+    solverIndex < 0 ||
+    completedIndex < 0 ||
+    relaxedDrcIndex < 0 ||
+    p50Index < 0 ||
+    p95Index < 0
+  ) {
+    return []
+  }
+
+  return summary.tableRowList.flatMap((row): BenchmarkRow[] => {
+    if (!Array.isArray(row) || !row.every((cell) => typeof cell === "string")) {
+      return []
+    }
+
+    const solverName = row[solverIndex]
+    const successRatePercent = parsePercentCell(row[completedIndex] ?? "")
+    const relaxedDrcRatePercent =
+      row[relaxedDrcIndex]?.trim().toLowerCase() === "n/a"
+        ? null
+        : parsePercentCell(row[relaxedDrcIndex] ?? "")
+    const p50TimeMs = parseTimeCell(row[p50Index] ?? "")
+    const p95TimeMs = parseTimeCell(row[p95Index] ?? "")
+
+    if (!solverName || successRatePercent === null) {
+      return []
+    }
+
+    return [
+      {
+        solverName,
+        totalTimeMs: 0,
+        p50TimeMs,
+        p95TimeMs,
+        successRatePercent,
+        relaxedDrcRatePercent,
+      },
+    ]
+  })
+}
+
+export const getBestBenchmarkRow = (
+  rowList: BenchmarkRow[],
+): BenchmarkRow | null => {
+  if (rowList.length === 0) return null
+
+  return rowList.reduce((best, row) => {
+    const bestRelaxedDrc = best.relaxedDrcRatePercent ?? -1
+    const rowRelaxedDrc = row.relaxedDrcRatePercent ?? -1
+    const bestP50 = best.p50TimeMs ?? Number.POSITIVE_INFINITY
+    const rowP50 = row.p50TimeMs ?? Number.POSITIVE_INFINITY
+    const bestP95 = best.p95TimeMs ?? Number.POSITIVE_INFINITY
+    const rowP95 = row.p95TimeMs ?? Number.POSITIVE_INFINITY
+
+    if (row.successRatePercent !== best.successRatePercent) {
+      return row.successRatePercent > best.successRatePercent ? row : best
+    }
+    if (rowRelaxedDrc !== bestRelaxedDrc) {
+      return rowRelaxedDrc > bestRelaxedDrc ? row : best
+    }
+    if (rowP50 !== bestP50) {
+      return rowP50 < bestP50 ? row : best
+    }
+    if (rowP95 !== bestP95) {
+      return rowP95 < bestP95 ? row : best
+    }
+    return best
+  })
+}
+
+export const getBenchmarkRowsFromSummary = (
+  summary: BenchmarkSummaryLike,
+): BenchmarkRow[] => {
+  if (Array.isArray(summary.resultRowList)) {
+    const rowList = summary.resultRowList.filter(isBenchmarkRow)
+    if (rowList.length > 0) return rowList
+  }
+
+  return getBenchmarkRowsFromSummaryTable(summary)
+}
+
+export const loadPreviousBestBenchmarkRow = async (
+  previousResultsPath: string | null | undefined,
+): Promise<BenchmarkRow | null> => {
+  if (!previousResultsPath) return null
+
+  const previousResultsText = await readFile(previousResultsPath, "utf8")
+  const previousResults = JSON.parse(
+    previousResultsText,
+  ) as BenchmarkSummaryLike
+  return getBestBenchmarkRow(getBenchmarkRowsFromSummary(previousResults))
+}

--- a/scripts/run-benchmark/outputTabled.ts
+++ b/scripts/run-benchmark/outputTabled.ts
@@ -8,10 +8,12 @@ import type { Scenario } from "types/run-benchmark/Scenario"
 const outputTabled = (inputs: {
   resultRowList: BenchmarkRow[]
   scenarioList: Scenario[]
+  previousBestRow?: BenchmarkRow | null
 }): string => {
-  const { resultRowList, scenarioList } = inputs
+  const { resultRowList, scenarioList, previousBestRow } = inputs
   const { tableHeaderList, tableRowList } = buildBenchmarkTableRows({
     resultRowList,
+    previousBestRow,
   })
 
   const columnWidths = tableHeaderList.map((header, columnIndex) => {

--- a/tests/run-benchmark/previous-best-result.test.ts
+++ b/tests/run-benchmark/previous-best-result.test.ts
@@ -1,0 +1,74 @@
+import { expect, test } from "bun:test"
+import { getCliOptionsFromArgList } from "scripts/run-benchmark/getCliOptionsFromArgList"
+import {
+  getBenchmarkRowsFromSummary,
+  getBestBenchmarkRow,
+} from "scripts/run-benchmark/loadPreviousBestBenchmarkRow"
+
+test("selects the previous best benchmark row by solve rate, drc rate, then p50", () => {
+  const best = getBestBenchmarkRow([
+    {
+      solverName: "slow-complete",
+      totalTimeMs: 0,
+      p50TimeMs: 5000,
+      p95TimeMs: 9000,
+      successRatePercent: 100,
+      relaxedDrcRatePercent: 100,
+    },
+    {
+      solverName: "fast-complete",
+      totalTimeMs: 0,
+      p50TimeMs: 1200,
+      p95TimeMs: 4000,
+      successRatePercent: 100,
+      relaxedDrcRatePercent: 100,
+    },
+    {
+      solverName: "partial",
+      totalTimeMs: 0,
+      p50TimeMs: 100,
+      p95TimeMs: 200,
+      successRatePercent: 80,
+      relaxedDrcRatePercent: 100,
+    },
+  ])
+
+  expect(best?.solverName).toBe("fast-complete")
+})
+
+test("reads previous benchmark rows from legacy summary table json", () => {
+  const rowList = getBenchmarkRowsFromSummary({
+    tableHeaderList: [
+      "Solver",
+      "Completed %",
+      "Relaxed DRC Pass %",
+      "P50 Time",
+      "P95 Time",
+    ],
+    tableRowList: [["capacity", "92.5%", "90.0%", "1.2s", "4.6s"]],
+  })
+
+  expect(rowList).toEqual([
+    {
+      solverName: "capacity",
+      totalTimeMs: 0,
+      p50TimeMs: 1200,
+      p95TimeMs: 4600,
+      successRatePercent: 92.5,
+      relaxedDrcRatePercent: 90,
+    },
+  ])
+})
+
+test("parses previous-results cli option", () => {
+  expect(
+    getCliOptionsFromArgList([
+      "--scenario-limit",
+      "5",
+      "--previous-results=results/benchmark-output.json",
+    ]),
+  ).toMatchObject({
+    scenarioCountLimit: 5,
+    previousResultsPath: "results/benchmark-output.json",
+  })
+})


### PR DESCRIPTION
﻿Fixes #69

@algora-pbc /claim #69

## Summary
- Add `--previous-results <path>` support for both benchmark entrypoints.
- Load a prior `benchmark-output.json`, pick the old best solver row, and show it in text/HTML summary output.
- Preserve compatibility with older summary JSON that only has table headers/rows.
- Include numeric `resultRowList` and `previousBestRow` in new summary JSON for future comparisons.

## Verification
- `bun test tests/run-benchmark/previous-best-result.test.ts`
- `bun x biome check scripts/run-benchmark/loadPreviousBestBenchmarkRow.ts scripts/run-benchmark/buildBenchmarkTableRows.ts scripts/run-benchmark/buildBenchmarkSummaryJson.ts scripts/run-benchmark/outputTabled.ts scripts/run-benchmark/generateHtmlVisualization/generateHeader.ts scripts/run-benchmark/generateHtmlVisualization/index.ts scripts/run-benchmark/getCliOptionsFromArgList.ts scripts/run-benchmark/index.ts lib/cli/run/register.ts tests/run-benchmark/previous-best-result.test.ts`
- `git diff --check`

Note: `bun x tsc --noEmit` currently fails on existing repo issues in `scripts/run-benchmark/solvers.ts` solver constructor typing and `vite.config.ts` module resolution, unrelated to this change.
